### PR TITLE
Add support for plotting raw point sequences

### DIFF
--- a/src/main/clj/plotter.clj
+++ b/src/main/clj/plotter.clj
@@ -26,9 +26,13 @@
    δy :- ifn? 
    coordinates :- ::coordinates])
 
+(deftag points
+  [coll :- seq?])
+
 (s/def ::any-curve
   (s/or :simple-curve ::curve
         #_#_:error-curve ::curve+error
+        :points ::points
         ))
 
 (s/def ::curves

--- a/src/main/clj/plotter.clj
+++ b/src/main/clj/plotter.clj
@@ -16,24 +16,24 @@
 
 (deftag curve
   [name :- string?
-   f :- ifn? 
+   f :- ifn?
    coordinates :- ::coordinates])
 
 (deftag curve+error
-  [name :- string? 
-   f :- ifn? 
+  [name :- string?
+   f :- ifn?
    δx :- ifn?
-   δy :- ifn? 
+   δy :- ifn?
    coordinates :- ::coordinates])
 
 (deftag points
-  [coll :- seq?])
+  [coll :- seq?
+   coordinates :- ::coordinates])
 
 (s/def ::any-curve
   (s/or :simple-curve ::curve
         #_#_:error-curve ::curve+error
-        :points ::points
-        ))
+        :points ::points))
 
 (s/def ::curves
   (s/* ::any-curve))


### PR DESCRIPTION
![2018-03-23-234431_1192x943_scrot](https://user-images.githubusercontent.com/704767/37861288-2647cf1a-2ef4-11e8-8742-d30607725285.png)

Adds support for treating arbitrary sequences of `(x, y)` pairs as a plottable, in addition to functions of `x`.